### PR TITLE
Configure gradle to refresh dynamic deps promptly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,13 @@ subprojects {
     jar.dependsOn updatePluginConfig
 }
 
+allprojects {
+    configurations.all {
+        resolutionStrategy.cacheDynamicVersionsFor 0, 'seconds'
+        resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+    }
+}
+
 
 buildscript {
     repositories {

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ checkout:
 
 dependencies:
   override:
-    - ./gradlew --refresh-dependencies assemble
+    - ./gradlew assemble
 
 test:
   override:


### PR DESCRIPTION
This saves us using --refresh-dependencies willy-nilly, which
wastes loads of time on the non-dynamic dependencies.
