### PR TITLE
Fix some TextPane layout weirdness.

### DIFF
--- a/ui_swing/src/com/dmdirc/addons/ui_swing/textpane/BasicTextLineRenderer.java
+++ b/ui_swing/src/com/dmdirc/addons/ui_swing/textpane/BasicTextLineRenderer.java
@@ -78,8 +78,7 @@ public class BasicTextLineRenderer implements LineRenderer {
 
     @Override
     public RenderResult render(final Graphics2D graphics, final float canvasWidth,
-            final float canvasHeight, final float drawPosY, final int line,
-            final boolean bottomLine) {
+            final float canvasHeight, final float drawPosY, final int line) {
         result.drawnAreas.clear();
         result.textLayouts.clear();
         result.totalHeight = 0;
@@ -94,10 +93,6 @@ public class BasicTextLineRenderer implements LineRenderer {
 
         float newDrawPosY = drawPosY;
 
-        if (bottomLine) {
-            newDrawPosY += DOUBLE_SIDE_PADDING;
-        }
-
         // Calculate layouts for each wrapped line.
         wrappedLines.clear();
         int chars = 0;
@@ -110,9 +105,6 @@ public class BasicTextLineRenderer implements LineRenderer {
         // Loop through each wrapped line
         for (int i = wrappedLines.size() - 1; i >= 0; i--) {
             final TextLayout layout = wrappedLines.get(i);
-
-            // Calculate the Y offset
-            newDrawPosY -= lineHeight;
 
             // Calculate the initial X position
             final float drawPosX;
@@ -129,6 +121,9 @@ public class BasicTextLineRenderer implements LineRenderer {
                 renderLine(graphics, (int) canvasWidth, line, drawPosX, newDrawPosY, i, chars,
                         layout);
             }
+
+            // Calculate the Y offset
+            newDrawPosY -= lineHeight;
         }
 
         result.totalHeight = drawPosY - newDrawPosY;
@@ -139,7 +134,7 @@ public class BasicTextLineRenderer implements LineRenderer {
             final float drawPosX, final float drawPosY, final int numberOfWraps, final int chars,
             final TextLayout layout) {
         graphics.setColor(textPane.getForeground());
-        layout.draw(graphics, drawPosX, drawPosY + layout.getDescent());
+        layout.draw(graphics, drawPosX, drawPosY);
         doHighlight(line, chars, layout, graphics, drawPosX, drawPosY);
         result.firstVisibleLine = line;
         final LineInfo lineInfo = new LineInfo(line, numberOfWraps);
@@ -205,12 +200,10 @@ public class BasicTextLineRenderer implements LineRenderer {
 
         as.addAttribute(TextAttribute.FOREGROUND, highlightForeground);
         as.addAttribute(TextAttribute.BACKGROUND, highlightBackground);
-        final TextLayout newLayout = new TextLayout(as.getIterator(),
-                g.getFontRenderContext());
-        final int trans = (int) (newLayout.getDescent() + drawPosY);
+        final TextLayout newLayout = new TextLayout(as.getIterator(), g.getFontRenderContext());
 
         g.translate(logicalHighlightShape.getBounds().getX(), 0);
-        newLayout.draw(g, drawPosX, trans);
+        newLayout.draw(g, drawPosX, (int) drawPosY);
         g.translate(-1 * logicalHighlightShape.getBounds().getX(), 0);
     }
 

--- a/ui_swing/src/com/dmdirc/addons/ui_swing/textpane/LineRenderer.java
+++ b/ui_swing/src/com/dmdirc/addons/ui_swing/textpane/LineRenderer.java
@@ -41,13 +41,11 @@ public interface LineRenderer {
      * @param canvasHeight The height of the canvas available to render on.
      * @param drawPosY The Y position to start rendering at.
      * @param line The number of the line to be rendered.
-     * @param bottomLine True if this line is the bottom-most (newest) line being rendered.
      * @return The result of the render. Callers should not store the result object, as it may
      * be recycled.
      */
     RenderResult render(final Graphics2D graphics, final float canvasWidth,
-            final float canvasHeight, final float drawPosY, final int line,
-            final boolean bottomLine);
+            final float canvasHeight, final float drawPosY, final int line);
 
     /**
      * Describes the results of a rendering attempt.

--- a/ui_swing/src/com/dmdirc/addons/ui_swing/textpane/TextPaneCanvas.java
+++ b/ui_swing/src/com/dmdirc/addons/ui_swing/textpane/TextPaneCanvas.java
@@ -160,7 +160,7 @@ class TextPaneCanvas extends JPanel implements MouseInputListener,
     private void paintOntoGraphics(final Graphics2D g) {
         final float formatWidth = getWidth() - DOUBLE_SIDE_PADDING;
         final float formatHeight = getHeight();
-        float drawPosY = formatHeight;
+        float drawPosY = formatHeight - DOUBLE_SIDE_PADDING;
 
         lineLayouts.clear();
         lineAreas.clear();
@@ -192,7 +192,7 @@ class TextPaneCanvas extends JPanel implements MouseInputListener,
     private float paintLineOntoGraphics(final Graphics2D g, final float formatWidth,
             final float formatHeight, final float drawPosY, final int line) {
         final RenderResult result = lineRenderer.render(g, formatWidth, formatHeight, drawPosY,
-                line, line == startLine);
+                line);
         lineAreas.putAll(result.drawnAreas);
         lineLayouts.putAll(result.textLayouts);
         firstVisibleLine = result.firstVisibleLine;


### PR DESCRIPTION
Stop adding descents all over the place. This stops the highlight
rectangles being slightly offset and allowing descenders to peek
out.

Also adjust the initial Y offset to include padding, and increment
it in the right place.

Fixes #25
