### PR TITLE
Set versions on plugins properly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /build
 */build
 /dist
+/dist-versioned
 /lib
 *.iml
 /.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,10 @@
 // DMDirc plugins build script
 subprojects {
+    def jgit = new org.mdonoughe.JGitDescribeTask()
+    jgit.dir = new File(projectDir.parent, '.git')
+    jgit.subDir = projectDir
+    project.version = jgit.getDescription() + '-SNAPSHOT'
+
     apply plugin: 'java'
     apply plugin: 'findbugs'
     apply plugin: 'pmd'
@@ -63,15 +68,8 @@ subprojects {
     }
 
     task updatePluginConfig(dependsOn: copyPluginConfig) << {
-        def gitDir = new File(projectDir.parent, '.git')
-
-        def jgit = new org.mdonoughe.JGitDescribeTask()
-        jgit.dir = gitDir
-        jgit.subDir = projectDir
-
-        ext.version = jgit.getDescription()
         def targetFile = new File(buildDir, 'plugin.config')
-        targetFile << "\n\nversion:\n  number=${version}"
+        targetFile << "\n\nversion:\n  number=${project.version}"
 
         targetFile << "\n\nbuildenv:\n"
         def compileConfiguration = project.configurations.getByName("compile")
@@ -117,8 +115,15 @@ subprojects {
             into "../dist/"
             rename ".*", "${project.name}.jar"
         }
+
+        copy {
+            from jar.archivePath
+            into "../dist-versioned/"
+            rename ".*", "${project.name}-${project.version}.jar"
+        }
     }
     jar.outputs.file "../dist/${project.name}.jar"
+    jar.outputs.file "../dist-versioned/${project.name}-${project.version}.jar"
 
     jar.dependsOn updatePluginConfig
 }


### PR DESCRIPTION
This makes the plugins include their version in the output file
name, and when used as a dependency.

Also create a dist-versioned directory which accumulates versioned
plugins.
