### PR TITLE
Use SystemInfo in IdentClient.

### DIFF
--- a/identd/src/com/dmdirc/addons/identd/IdentClient.java
+++ b/identd/src/com/dmdirc/addons/identd/IdentClient.java
@@ -30,6 +30,7 @@ import com.dmdirc.interfaces.User;
 import com.dmdirc.interfaces.config.AggregateConfigProvider;
 import com.dmdirc.interfaces.config.ReadOnlyConfigProvider;
 import com.dmdirc.logger.ErrorLevel;
+import com.dmdirc.util.SystemInfo;
 import com.dmdirc.util.io.StreamUtils;
 
 import java.io.BufferedReader;
@@ -57,26 +58,23 @@ public class IdentClient implements Runnable {
     private final AggregateConfigProvider config;
     /** This plugin's settings domain. */
     private final String domain;
+    /** System wrapper to use. */
+    private final SystemInfo systemInfo;
 
     /**
      * Create the IdentClient.
-     *
-     * @param eventBus      The event bus to post errors on
-     * @param server        The server that owns this
-     * @param socket        The socket we are handing
-     * @param connectionManager Server manager to retrieve servers from
-     * @param config        Global config to read settings from
-     * @param domain        This plugin's settings domain
      */
-    public IdentClient(final DMDircMBassador eventBus, final IdentdServer server, final Socket socket,
-            final ConnectionManager connectionManager, final AggregateConfigProvider config,
-            final String domain) {
+    public IdentClient(final DMDircMBassador eventBus, final IdentdServer server,
+            final Socket socket, final ConnectionManager connectionManager,
+            final AggregateConfigProvider config, final String domain,
+            final SystemInfo systemInfo) {
         this.eventBus = eventBus;
         this.server = server;
         this.socket = socket;
         this.connectionManager = connectionManager;
         this.config = config;
         this.domain = domain;
+        this.systemInfo = systemInfo;
     }
 
     /**
@@ -149,7 +147,7 @@ public class IdentClient implements Runnable {
             return String.format("%d , %d : ERROR : HIDDEN-USER", myPort, theirPort);
         }
 
-        final String osName = System.getProperty("os.name").toLowerCase();
+        final String osName = systemInfo.getProperty("os.name").toLowerCase();
         final String os;
 
         final String customSystem = config.getOption(domain, "advanced.customSystem");
@@ -189,7 +187,7 @@ public class IdentClient implements Runnable {
         } else if (connection != null && config.getOptionBool(domain, "general.useUsername")) {
             username = connection.getLocalUser().flatMap(User::getUsername).orElse("Unknown");
         } else {
-            username = System.getProperty("user.name");
+            username = systemInfo.getProperty("user.name");
         }
 
         return String.format("%d , %d : USERID : %s : %s", myPort, theirPort, escapeString(os),

--- a/identd/src/com/dmdirc/addons/identd/IdentdServer.java
+++ b/identd/src/com/dmdirc/addons/identd/IdentdServer.java
@@ -29,6 +29,7 @@ import com.dmdirc.interfaces.ConnectionManager;
 import com.dmdirc.interfaces.config.AggregateConfigProvider;
 import com.dmdirc.logger.ErrorLevel;
 import com.dmdirc.plugins.PluginDomain;
+import com.dmdirc.util.SystemInfo;
 
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -59,6 +60,8 @@ public final class IdentdServer implements Runnable {
     private final AggregateConfigProvider config;
     /** This plugin's config settings domain. */
     private final String domain;
+    /** System info wrapper to use for the ident client. */
+    private final SystemInfo systemInfo;
 
     /**
      * Create the IdentdServer.
@@ -72,11 +75,13 @@ public final class IdentdServer implements Runnable {
     public IdentdServer(final DMDircMBassador eventBus,
             final ConnectionManager connectionManager,
             @GlobalConfig final AggregateConfigProvider config,
-            @PluginDomain(IdentdPlugin.class) final String domain) {
+            @PluginDomain(IdentdPlugin.class) final String domain,
+            final SystemInfo systemInfo) {
         this.eventBus = eventBus;
         this.connectionManager = connectionManager;
         this.config = config;
         this.domain = domain;
+        this.systemInfo = systemInfo;
     }
 
     /**
@@ -89,7 +94,7 @@ public final class IdentdServer implements Runnable {
             try {
                 final Socket clientSocket = serverSocket.accept();
                 final IdentClient client = new IdentClient(eventBus, this, clientSocket,
-                        connectionManager, config, domain);
+                        connectionManager, config, domain, systemInfo);
                 client.start();
                 addClient(client);
             } catch (IOException e) {

--- a/identd/test/com/dmdirc/addons/identd/IdentClientTest.java
+++ b/identd/test/com/dmdirc/addons/identd/IdentClientTest.java
@@ -29,6 +29,7 @@ import com.dmdirc.interfaces.User;
 import com.dmdirc.interfaces.config.AggregateConfigProvider;
 import com.dmdirc.parser.irc.IRCClientInfo;
 import com.dmdirc.parser.irc.IRCParser;
+import com.dmdirc.util.SystemInfo;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,6 +55,7 @@ public class IdentClientTest {
     @Mock private User user;
     @Mock private AggregateConfigProvider config;
     @Mock private DMDircMBassador eventBus;
+    @Mock private SystemInfo systemInfo;
 
     protected IdentClient getClient() {
         final List<Connection> servers = new ArrayList<>();
@@ -69,7 +71,7 @@ public class IdentClientTest {
         when(user.getNickname()).thenReturn("nickname");
         when(user.getUsername()).thenReturn(Optional.of("username"));
 
-        return new IdentClient(eventBus, null, null, sm, config, "plugin-Identd");
+        return new IdentClient(eventBus, null, null, sm, config, "plugin-Identd", systemInfo);
     }
 
     @Test
@@ -156,6 +158,8 @@ public class IdentClientTest {
         when(acp.getOption("plugin-Identd", "advanced.customSystem")).thenReturn("a:b\\c,d");
         when(acp.getOptionBool("plugin-Identd", "general.useCustomName")).thenReturn(false);
         when(acp.getOption("plugin-Identd", "general.customName")).thenReturn("");
+        when(systemInfo.getProperty("user.name")).thenReturn("test");
+        when(systemInfo.getProperty("os.name")).thenReturn("test");
 
         final String response = getClient().getIdentResponse("50, 50", acp);
         assertContains("Special characters must be quoted in system names",
@@ -170,6 +174,8 @@ public class IdentClientTest {
         when(acp.getOption("plugin-Identd", "advanced.customSystem")).thenReturn("");
         when(acp.getOptionBool("plugin-Identd", "general.useCustomName")).thenReturn(true);
         when(acp.getOption("plugin-Identd", "general.customName")).thenReturn("a:b\\c,d");
+        when(systemInfo.getProperty("user.name")).thenReturn("test");
+        when(systemInfo.getProperty("os.name")).thenReturn("test");
 
         final String response = getClient().getIdentResponse("50, 50", acp);
         assertContains("Special characters must be quoted in custom names",
@@ -184,6 +190,8 @@ public class IdentClientTest {
         when(acp.getOption("plugin-Identd", "advanced.customSystem")).thenReturn("system");
         when(acp.getOptionBool("plugin-Identd", "general.useCustomName")).thenReturn(true);
         when(acp.getOption("plugin-Identd", "general.customName")).thenReturn("name");
+        when(systemInfo.getProperty("user.name")).thenReturn("test");
+        when(systemInfo.getProperty("os.name")).thenReturn("test");
 
         final String response = getClient().getIdentResponse("50, 60", acp);
         final String[] bits = response.split(":");
@@ -200,8 +208,8 @@ public class IdentClientTest {
     public void testOSWindows() {
         when(acp.getOptionBool("plugin-Identd", "advanced.alwaysOn")).thenReturn(true);
         when(acp.getOptionBool("plugin-Identd", "advanced.useCustomSystem")).thenReturn(false);
-        System.setProperty("user.name", "test");
-        System.setProperty("os.name", "windows");
+        when(systemInfo.getProperty("user.name")).thenReturn("test");
+        when(systemInfo.getProperty("os.name")).thenReturn("windows");
 
         final String response = getClient().getIdentResponse("50, 50", acp);
         assertEquals("50 , 50 : USERID : WIN32 : test", response);
@@ -211,8 +219,8 @@ public class IdentClientTest {
     public void testOSMac() {
         when(acp.getOptionBool("plugin-Identd", "advanced.alwaysOn")).thenReturn(true);
         when(acp.getOptionBool("plugin-Identd", "advanced.useCustomSystem")).thenReturn(false);
-        System.setProperty("user.name", "test");
-        System.setProperty("os.name", "mac");
+        when(systemInfo.getProperty("user.name")).thenReturn("test");
+        when(systemInfo.getProperty("os.name")).thenReturn("mac");
 
         final String response = getClient().getIdentResponse("50, 50", acp);
         assertEquals("50 , 50 : USERID : MACOS : test", response);
@@ -222,8 +230,8 @@ public class IdentClientTest {
     public void testOSLinux() {
         when(acp.getOptionBool("plugin-Identd", "advanced.alwaysOn")).thenReturn(true);
         when(acp.getOptionBool("plugin-Identd", "advanced.useCustomSystem")).thenReturn(false);
-        System.setProperty("user.name", "test");
-        System.setProperty("os.name", "linux");
+        when(systemInfo.getProperty("user.name")).thenReturn("test");
+        when(systemInfo.getProperty("os.name")).thenReturn("linux");
 
         final String response = getClient().getIdentResponse("50, 50", acp);
         assertEquals("50 , 50 : USERID : UNIX : test", response);
@@ -233,8 +241,8 @@ public class IdentClientTest {
     public void testOSBSD() {
         when(acp.getOptionBool("plugin-Identd", "advanced.alwaysOn")).thenReturn(true);
         when(acp.getOptionBool("plugin-Identd", "advanced.useCustomSystem")).thenReturn(false);
-        System.setProperty("user.name", "test");
-        System.setProperty("os.name", "bsd");
+        when(systemInfo.getProperty("user.name")).thenReturn("test");
+        when(systemInfo.getProperty("os.name")).thenReturn("bsd");
 
         final String response = getClient().getIdentResponse("50, 50", acp);
         assertEquals("50 , 50 : USERID : UNIX-BSD : test", response);
@@ -244,8 +252,8 @@ public class IdentClientTest {
     public void testOSOS2() {
         when(acp.getOptionBool("plugin-Identd", "advanced.alwaysOn")).thenReturn(true);
         when(acp.getOptionBool("plugin-Identd", "advanced.useCustomSystem")).thenReturn(false);
-        System.setProperty("user.name", "test");
-        System.setProperty("os.name", "os/2");
+        when(systemInfo.getProperty("user.name")).thenReturn("test");
+        when(systemInfo.getProperty("os.name")).thenReturn("os/2");
 
         final String response = getClient().getIdentResponse("50, 50", acp);
         assertEquals("50 , 50 : USERID : OS/2 : test", response);
@@ -255,8 +263,8 @@ public class IdentClientTest {
     public void testOSUnix() {
         when(acp.getOptionBool("plugin-Identd", "advanced.alwaysOn")).thenReturn(true);
         when(acp.getOptionBool("plugin-Identd", "advanced.useCustomSystem")).thenReturn(false);
-        System.setProperty("user.name", "test");
-        System.setProperty("os.name", "unix");
+        when(systemInfo.getProperty("user.name")).thenReturn("test");
+        when(systemInfo.getProperty("os.name")).thenReturn("unix");
 
         final String response = getClient().getIdentResponse("50, 50", acp);
         assertEquals("50 , 50 : USERID : UNIX : test", response);
@@ -266,8 +274,8 @@ public class IdentClientTest {
     public void testOSIrix() {
         when(acp.getOptionBool("plugin-Identd", "advanced.alwaysOn")).thenReturn(true);
         when(acp.getOptionBool("plugin-Identd", "advanced.useCustomSystem")).thenReturn(false);
-        System.setProperty("user.name", "test");
-        System.setProperty("os.name", "irix");
+        when(systemInfo.getProperty("user.name")).thenReturn("test");
+        when(systemInfo.getProperty("os.name")).thenReturn("irix");
 
         final String response = getClient().getIdentResponse("50, 50", acp);
         assertEquals("50 , 50 : USERID : IRIX : test", response);
@@ -277,19 +285,8 @@ public class IdentClientTest {
     public void testOSUnknown() {
         when(acp.getOptionBool("plugin-Identd", "advanced.alwaysOn")).thenReturn(true);
         when(acp.getOptionBool("plugin-Identd", "advanced.useCustomSystem")).thenReturn(false);
-        System.setProperty("user.name", "test");
-        System.setProperty("os.name", "test");
-
-        final String response = getClient().getIdentResponse("50, 50", acp);
-        assertEquals("50 , 50 : USERID : UNKNOWN : test", response);
-    }
-
-    @Test
-    public void testNameSystem() {
-        when(acp.getOptionBool("plugin-Identd", "advanced.alwaysOn")).thenReturn(true);
-        when(acp.getOptionBool("plugin-Identd", "advanced.useCustomSystem")).thenReturn(false);
-        System.setProperty("user.name", "test");
-        System.setProperty("os.name", "test");
+        when(systemInfo.getProperty("user.name")).thenReturn("test");
+        when(systemInfo.getProperty("os.name")).thenReturn("test");
 
         final String response = getClient().getIdentResponse("50, 50", acp);
         assertEquals("50 , 50 : USERID : UNKNOWN : test", response);
@@ -300,8 +297,8 @@ public class IdentClientTest {
         when(acp.getOptionBool("plugin-Identd", "advanced.alwaysOn")).thenReturn(true);
         when(acp.getOptionBool("plugin-Identd", "general.useCustomName")).thenReturn(true);
         when(acp.getOption("plugin-Identd", "general.customName")).thenReturn("name");
-        System.setProperty("user.name", "test");
-        System.setProperty("os.name", "test");
+        when(systemInfo.getProperty("user.name")).thenReturn("test");
+        when(systemInfo.getProperty("os.name")).thenReturn("test");
 
         final String response = getClient().getIdentResponse("50, 50", acp);
         assertEquals("50 , 50 : USERID : UNKNOWN : name", response);
@@ -310,8 +307,8 @@ public class IdentClientTest {
     @Test
     public void testNameNickname() {
         when(acp.getOptionBool("plugin-Identd", "general.useNickname")).thenReturn(true);
-        System.setProperty("user.name", "test");
-        System.setProperty("os.name", "test");
+        when(systemInfo.getProperty("user.name")).thenReturn("test");
+        when(systemInfo.getProperty("os.name")).thenReturn("test");
 
         final String response = getClient().getIdentResponse("60, 50", acp);
         assertEquals("60 , 50 : USERID : UNKNOWN : nickname", response);
@@ -320,16 +317,16 @@ public class IdentClientTest {
     @Test
     public void testNameUsername() {
         when(acp.getOptionBool("plugin-Identd", "general.useUsername")).thenReturn(true);
-        System.setProperty("user.name", "test");
-        System.setProperty("os.name", "test");
+        when(systemInfo.getProperty("user.name")).thenReturn("test");
+        when(systemInfo.getProperty("os.name")).thenReturn("test");
 
         final String response = getClient().getIdentResponse("60, 50", acp);
         assertEquals("60 , 50 : USERID : UNKNOWN : username", response);
     }
 
     private static void assertContains(final String msg, final String haystack,
-            final String needle) {
-        assertTrue(msg, haystack.indexOf(needle) > -1);
+            final CharSequence needle) {
+        assertTrue(msg, haystack.contains(needle));
     }
 
     private static void assertStartsWith(final String msg, final String haystack,


### PR DESCRIPTION
This allows the properties to be mocked out in tests, instead
of trying to set global system properties which screw up the
JVM...