### PR TITLE
ErrorsDialog tidying.

### DIFF
--- a/ui_swing/src/com/dmdirc/addons/ui_swing/dialogs/errors/ErrorsDialog.java
+++ b/ui_swing/src/com/dmdirc/addons/ui_swing/dialogs/errors/ErrorsDialog.java
@@ -116,6 +116,7 @@ public class ErrorsDialog extends StandardDialog {
         splitPane = getSplitPane();
         table = new PackingTable(tableModel, tableScrollPane);
         table.setAutoCreateRowSorter(true);
+        table.setAutoscrolls(false);
         table.getModel().addTableModelListener(table);
         tableScrollPane.setViewportView(table);
         table.setPreferredScrollableViewportSize(new Dimension(600, 150));

--- a/ui_swing/src/com/dmdirc/addons/ui_swing/dialogs/errors/ErrorsDialogController.java
+++ b/ui_swing/src/com/dmdirc/addons/ui_swing/dialogs/errors/ErrorsDialogController.java
@@ -140,7 +140,7 @@ class ErrorsDialogController implements ErrorsDialogModelListener {
     public void errorStatusChanged(final DisplayableError error) {
         UIUtilities.invokeLater(() -> {
             final int index = tableModel.getIndex(error);
-            tableModel.fireTableRowsUpdated(index, index);
+            tableModel.fireTableCellUpdated(index, 1);
             checkEnabledStates();
         });
     }


### PR DESCRIPTION
Don't auto scroll to selected error.
Don't update the whole row just for a cell change.