### PR TITLE
Try to speed up CI a bit.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -37,11 +37,7 @@ dependencies:
 
 test:
   override:
-    - ./gradlew --stacktrace --parallel plugins:jar plugins:test:
-        pwd:
-          ../meta
-  post:
-    - ./gradlew plugins:coveralls:
+    - ./gradlew --stacktrace plugins:jar plugins:test plugins:coveralls:
         pwd:
           ../meta
 


### PR DESCRIPTION
Try without using gradle's parallel function (probably adds more
overhead for the tiny number of tests we have), and combine
coveralls with the main test run.