### PR TITLE
Add snapshot repository.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,8 @@ subprojects {
 
     repositories {
         mavenCentral()
-        maven {
-            url 'http://artifactory.dmdirc.com/artifactory/repo'
-        }
+        maven { url 'http://artifactory.dmdirc.com/artifactory/repo' }
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     }
 
     dependencies {


### PR DESCRIPTION
Because plugins depends on client, they need to be able to
find the client's transitive dependencies as well.