### PR TITLE
Use events for some more plugin outputs.

### DIFF
--- a/logging/src/com/dmdirc/addons/logging/HistoryWindow.java
+++ b/logging/src/com/dmdirc/addons/logging/HistoryWindow.java
@@ -34,10 +34,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.text.ParsePosition;
-import java.text.SimpleDateFormat;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -84,12 +81,8 @@ public class HistoryWindow extends FrameContainer {
         try (final ReverseFileReader reader = new ReverseFileReader(logFile)) {
             final List<String> lines = reader.getLines(Math.min(limit, numLines));
             Collections.reverse(lines);
-            lines.forEach(l -> {
-                final ParsePosition pos = new ParsePosition(0);
-                final Date date = new SimpleDateFormat("[dd/MM/yyyy HH:mm:ss]").parse(l, pos);
-                final String text = l.substring(pos.getIndex()+1);
-                addLine(text, date);
-            });
+            lines.forEach(l ->
+                    getEventBus().publishAsync(new HistoricalLineRestoredEvent(this, l)));
         } catch (IOException | SecurityException ex) {
             LOG.warn(USER_ERROR, "Unable to read log file.", ex);
         }

--- a/parserdebug/src/com/dmdirc/addons/parserdebug/DebugWindow.java
+++ b/parserdebug/src/com/dmdirc/addons/parserdebug/DebugWindow.java
@@ -24,13 +24,13 @@ package com.dmdirc.addons.parserdebug;
 
 import com.dmdirc.DMDircMBassador;
 import com.dmdirc.FrameContainer;
+import com.dmdirc.events.CommandOutputEvent;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.parser.interfaces.Parser;
 import com.dmdirc.ui.core.components.WindowComponent;
 import com.dmdirc.ui.messages.BackBufferFactory;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Optional;
 
 /**
@@ -74,8 +74,9 @@ public class DebugWindow extends FrameContainer {
      * Set the parser to null to stop us holding onto parsers when the server connection is closed.
      */
     public void unsetParser() {
-        addLine("======================", new Date());
-        addLine("Unset parser: " + parser, new Date());
+        getEventBus().publishAsync(new CommandOutputEvent(this,
+                "======================\n" +
+                "Unset parser: " + parser));
         parser = null;
     }
 

--- a/parserdebug/src/com/dmdirc/addons/parserdebug/ParserDebugManager.java
+++ b/parserdebug/src/com/dmdirc/addons/parserdebug/ParserDebugManager.java
@@ -23,6 +23,7 @@
 package com.dmdirc.addons.parserdebug;
 
 import com.dmdirc.DMDircMBassador;
+import com.dmdirc.events.CommandOutputEvent;
 import com.dmdirc.events.ServerDisconnectedEvent;
 import com.dmdirc.interfaces.Connection;
 import com.dmdirc.parser.events.DebugInfoEvent;
@@ -30,7 +31,6 @@ import com.dmdirc.parser.interfaces.Parser;
 import com.dmdirc.ui.WindowManager;
 import com.dmdirc.ui.messages.BackBufferFactory;
 
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -96,9 +96,10 @@ public class ParserDebugManager {
                 connection, eventBus, backBufferFactory);
         windowManager.addWindow(connection.getWindowModel(), window);
         registeredParsers.put(parser, window);
-        window.addLine("======================", new Date());
-        window.addLine("Started Monitoring: " + parser, new Date());
-        window.addLine("======================", new Date());
+        window.getEventBus().publishAsync(new CommandOutputEvent(window,
+                "======================\n" +
+                "Started Monitoring: " + parser + '\n' +
+                "======================"));
     }
 
     /**
@@ -110,9 +111,10 @@ public class ParserDebugManager {
     public void removeParser(final Parser parser, final boolean close) {
         parser.getCallbackManager().unsubscribe(this);
         final DebugWindow window = registeredParsers.get(parser);
-        window.addLine("======================", new Date());
-        window.addLine("No Longer Monitoring: " + parser + " (User Requested)", new Date());
-        window.addLine("======================", new Date());
+        window.getEventBus().publishAsync(new CommandOutputEvent(window,
+                "======================\n" +
+                "No Longer Monitoring: " + parser + " (User Requested)\n" +
+                "======================"));
         if (close) {
             window.close();
         }
@@ -142,7 +144,8 @@ public class ParserDebugManager {
     public void onDebugInfo(final DebugInfoEvent event) {
         final DebugWindow window = registeredParsers.get(event.getParser());
         if (window != null) {
-            window.addLine(String.format("[%d] %s%n", event.getLevel(), event.getData()), new Date());
+            window.getEventBus().publishAsync(new CommandOutputEvent(window,
+                    String.format("[%d] %s%n", event.getLevel(), event.getData())));
         }
     }
 


### PR DESCRIPTION
This slightly changes how the logging plugin history window
works - instead of parsing dates and using DMDirc timestamps,
it just shows the logged timestamp like the backbuffer does.

As history tends to span several days this seems more useful.

Issue DMDirc/DMDirc#426