### PR TITLE
Convert events to use new date APIs.

### DIFF
--- a/debug/src/com/dmdirc/addons/debug/RawDataInEvent.java
+++ b/debug/src/com/dmdirc/addons/debug/RawDataInEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.addons.debug;
 import com.dmdirc.events.BaseDisplayableEvent;
 import com.dmdirc.interfaces.WindowModel;
 
+import java.time.LocalDateTime;
+
 /**
  * Event raised when a raw data in line is displayed.
  */
@@ -32,7 +34,8 @@ public class RawDataInEvent extends BaseDisplayableEvent {
 
     private final String line;
 
-    public RawDataInEvent(final long timestamp, final WindowModel source, final String line) {
+    public RawDataInEvent(final LocalDateTime timestamp, final WindowModel source,
+            final String line) {
         super(timestamp, source);
         this.line = line;
     }

--- a/debug/src/com/dmdirc/addons/debug/RawDataOutEvent.java
+++ b/debug/src/com/dmdirc/addons/debug/RawDataOutEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.addons.debug;
 import com.dmdirc.events.BaseDisplayableEvent;
 import com.dmdirc.interfaces.WindowModel;
 
+import java.time.LocalDateTime;
+
 /**
  * Event raised when a raw data out line is displayed.
  */
@@ -32,7 +34,8 @@ public class RawDataOutEvent extends BaseDisplayableEvent {
 
     private final String line;
 
-    public RawDataOutEvent(final long timestamp, final WindowModel source, final String line) {
+    public RawDataOutEvent(final LocalDateTime timestamp, final WindowModel source,
+            final String line) {
         super(timestamp, source);
         this.line = line;
     }

--- a/logging/src/com/dmdirc/addons/logging/HistoricalLineRestoredEvent.java
+++ b/logging/src/com/dmdirc/addons/logging/HistoricalLineRestoredEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.addons.logging;
 import com.dmdirc.events.BaseDisplayableEvent;
 import com.dmdirc.interfaces.WindowModel;
 
+import java.time.LocalDateTime;
+
 /**
  * Event raised when a line from the log is restored into a window.
  */
@@ -32,7 +34,7 @@ public class HistoricalLineRestoredEvent extends BaseDisplayableEvent {
 
     private final String line;
 
-    public HistoricalLineRestoredEvent(final long timestamp, final WindowModel source,
+    public HistoricalLineRestoredEvent(final LocalDateTime timestamp, final WindowModel source,
             final String line) {
         super(timestamp, source);
         this.line = line;

--- a/tabcompletion_bash/src/com/dmdirc/addons/tabcompletion_bash/BashDisambiguationEvent.java
+++ b/tabcompletion_bash/src/com/dmdirc/addons/tabcompletion_bash/BashDisambiguationEvent.java
@@ -25,6 +25,8 @@ package com.dmdirc.addons.tabcompletion_bash;
 import com.dmdirc.events.BaseDisplayableEvent;
 import com.dmdirc.interfaces.WindowModel;
 
+import java.time.LocalDateTime;
+
 /**
  * Event raised when multiple potential results match a bash-style completion attempt.
  */
@@ -32,7 +34,7 @@ public class BashDisambiguationEvent extends BaseDisplayableEvent {
 
     private final String matches;
 
-    public BashDisambiguationEvent(final long timestamp, final WindowModel source,
+    public BashDisambiguationEvent(final LocalDateTime timestamp, final WindowModel source,
             final String matches) {
         super(timestamp, source);
         this.matches = matches;


### PR DESCRIPTION
Java 8 introduces a sane API for dates; to store datettimes
we should now be using LocalDateTime.