### PR TITLE
Add source checks for eventbus handlers.

### DIFF
--- a/awaycolours/src/com/dmdirc/addons/awaycolours/AwayColoursManager.java
+++ b/awaycolours/src/com/dmdirc/addons/awaycolours/AwayColoursManager.java
@@ -75,8 +75,8 @@ public class AwayColoursManager {
 
     @Handler
     public void handleAwayEvent(final ChannelUserAwayEvent event) {
-            event.getUser().setDisplayProperty(DisplayProperty.FOREGROUND_COLOUR, colour);
-            event.getChannel().refreshClients();
+        event.getUser().setDisplayProperty(DisplayProperty.FOREGROUND_COLOUR, colour);
+        event.getChannel().refreshClients();
     }
 
     @Handler

--- a/channelwho/src/com/dmdirc/addons/channelwho/ConnectionHandler.java
+++ b/channelwho/src/com/dmdirc/addons/channelwho/ConnectionHandler.java
@@ -87,13 +87,11 @@ public class ConnectionHandler {
 
     @VisibleForTesting
     void checkWho() {
-        connectionManager.getConnections().forEach(
-                connection -> connection.getGroupChatManager().getChannels().forEach(channel -> {
-                    if (channel.getWindowModel().getConfigManager()
-                            .getOptionBool(domain, "sendwho")) {
-                        channel.requestUsersInfo();
-                    }
-                }));
+        connection.getGroupChatManager().getChannels().forEach(channel -> {
+            if (channel.getWindowModel().getConfigManager().getOptionBool(domain, "sendwho")) {
+                channel.requestUsersInfo();
+            }
+        });
     }
 
     @VisibleForTesting
@@ -109,7 +107,8 @@ public class ConnectionHandler {
     @VisibleForTesting
     @Handler
     void handleAwayEvent(final ChannelUserAwayEvent event) {
-        if (!event.getReason().isPresent()) {
+        if (event.getChannel().getConnection().equals(connection)
+                && !event.getReason().isPresent()) {
             event.setDisplayProperty(DisplayProperty.DO_NOT_DISPLAY, true);
             final boolean notseen = !users.containsKey(event.getUser().getNickname());
             users.put(event.getUser().getNickname(), event.getUser());
@@ -123,7 +122,7 @@ public class ConnectionHandler {
     @VisibleForTesting
     @Handler
     void handleServerNumericEvent(final ServerNumericEvent event) {
-        if (event.getNumeric() == 301) {
+        if (event.getConnection().equals(connection) && event.getNumeric() == 301) {
             final String nickname = event.getArgs()[3];
             final String reason = event.getArgs()[4];
             users.removeAll(nickname).forEach(u -> u.getGroupChat().getEventBus()

--- a/contactlist/src/com/dmdirc/addons/contactlist/ContactListListener.java
+++ b/contactlist/src/com/dmdirc/addons/contactlist/ContactListListener.java
@@ -70,27 +70,37 @@ public class ContactListListener {
 
     @Handler
     public void handleClientsUpdated(final NickListClientsChangedEvent event) {
-        event.getUsers().forEach(this::clientAdded);
+        if (event.getChannel().equals(groupChat)) {
+            event.getUsers().forEach(this::clientAdded);
+        }
     }
 
     @Handler
     public void handleClientAdded(final NickListClientAddedEvent event) {
-        clientAdded(event.getUser());
+        if (event.getChannel().equals(groupChat)) {
+            clientAdded(event.getUser());
+        }
     }
 
     @Handler
     public void handleUserAway(final ChannelUserAwayEvent event) {
-        clientAdded(event.getUser());
+        if (event.getChannel().equals(groupChat)) {
+            clientAdded(event.getUser());
+        }
     }
 
     @Handler
     public void handleUserBack(final ChannelUserBackEvent event) {
-        clientAdded(event.getUser());
+        if (event.getChannel().equals(groupChat)) {
+            clientAdded(event.getUser());
+        }
     }
 
     @Handler
     public void windowClosing(final FrameClosingEvent event) {
-        removeListeners();
+        if (event.getSource().equals(groupChat.getWindowModel())) {
+            removeListeners();
+        }
     }
 
     void clientAdded(final GroupChatUser client) {

--- a/debug/src/com/dmdirc/addons/debug/RawWindow.java
+++ b/debug/src/com/dmdirc/addons/debug/RawWindow.java
@@ -29,7 +29,6 @@ import com.dmdirc.parser.events.DataInEvent;
 import com.dmdirc.parser.events.DataOutEvent;
 import com.dmdirc.parser.interfaces.Parser;
 import com.dmdirc.ui.core.components.WindowComponent;
-import com.dmdirc.ui.input.TabCompleterFactory;
 import com.dmdirc.ui.messages.BackBufferFactory;
 
 import java.util.Arrays;
@@ -44,10 +43,7 @@ public class RawWindow extends FrameContainer {
 
     private final Connection connection;
 
-    public RawWindow(
-            final Connection connection,
-            final TabCompleterFactory tabCompleterFactory,
-            final BackBufferFactory backBufferFactory) {
+    public RawWindow(final Connection connection, final BackBufferFactory backBufferFactory) {
         super("raw", "Raw", "(Raw log)",
                 connection.getWindowModel().getConfigManager(),
                 backBufferFactory,
@@ -75,7 +71,11 @@ public class RawWindow extends FrameContainer {
 
     @Handler
     public void handleServerConnecting(final ServerConnectingEvent connectingEvent) {
-        connection.getParser().map(Parser::getCallbackManager).ifPresent(c -> c.subscribe(this));
+        if (connectingEvent.getConnection().equals(connection)) {
+            connection.getParser()
+                    .map(Parser::getCallbackManager)
+                    .ifPresent(c -> c.subscribe(this));
+        }
     }
 
     @Handler

--- a/debug/src/com/dmdirc/addons/debug/RawWindowFactory.java
+++ b/debug/src/com/dmdirc/addons/debug/RawWindowFactory.java
@@ -58,8 +58,7 @@ public class RawWindowFactory {
     }
 
     public RawWindow getRawWindow(final Connection connection) {
-        final RawWindow rawWindow = new RawWindow(connection,
-                tabCompleterFactory,  backBufferFactory);
+        final RawWindow rawWindow = new RawWindow(connection, backBufferFactory);
         rawWindow.setInputModel(
                 new DefaultInputModel(
                         connection::sendLine,

--- a/debug/src/com/dmdirc/addons/debug/commands/EventBusViewer.java
+++ b/debug/src/com/dmdirc/addons/debug/commands/EventBusViewer.java
@@ -124,7 +124,9 @@ public class EventBusViewer extends DebugCommand {
 
         @Handler
         public void handleFrameClosing(final FrameClosingEvent event) {
-            eventBus.unsubscribe(this);
+            if (event.getSource().equals(target)) {
+                eventBus.unsubscribe(this);
+            }
         }
 
         @Handler

--- a/identd/src/com/dmdirc/addons/identd/IdentdManager.java
+++ b/identd/src/com/dmdirc/addons/identd/IdentdManager.java
@@ -77,7 +77,6 @@ public class IdentdManager {
      * Called when the plugin is loaded.
      */
     public void onLoad() {
-        // Add action hooks
         eventBus.subscribe(this);
 
         if (config.getOptionBool(domain, "advanced.alwaysOn")) {
@@ -97,11 +96,11 @@ public class IdentdManager {
     @Handler
     public void handleServerConnecting(final ServerConnectingEvent event) {
         synchronized (connections) {
-                if (connections.isEmpty()) {
-                    server.startServer();
-                }
-                connections.add(event.getConnection());
+            if (connections.isEmpty()) {
+                server.startServer();
             }
+            connections.add(event.getConnection());
+        }
     }
 
     @Handler
@@ -116,15 +115,13 @@ public class IdentdManager {
 
     private void handleServerRemoved(final Connection connection) {
         synchronized (connections) {
-                connections.remove(connection);
+            connections.remove(connection);
 
-                if (connections.isEmpty() && !config.getOptionBool(domain, "advanced.alwaysOn")) {
-                    server.stopServer();
-                }
+            if (connections.isEmpty() && !config.getOptionBool(domain, "advanced.alwaysOn")) {
+                server.stopServer();
             }
+        }
     }
-
-
 
     @Handler
     public void showConfig(final ClientPrefsOpenedEvent event) {

--- a/jpq/src/com/dmdirc/addons/jpq/GroupChatHandler.java
+++ b/jpq/src/com/dmdirc/addons/jpq/GroupChatHandler.java
@@ -77,21 +77,27 @@ public class GroupChatHandler {
     @VisibleForTesting
     @Handler
     void handleJoin(final ChannelJoinEvent event) {
-        hideEvent(event);
+        if (event.getChannel().equals(groupChat)) {
+            hideEvent(event);
+        }
     }
 
     @SuppressWarnings("TypeMayBeWeakened")
     @VisibleForTesting
     @Handler
     void handlePart(final ChannelPartEvent event) {
-        hideEvent(event);
+        if (event.getChannel().equals(groupChat)) {
+            hideEvent(event);
+        }
     }
 
     @SuppressWarnings("TypeMayBeWeakened")
     @VisibleForTesting
     @Handler
     void handleQuit(final ChannelQuitEvent event) {
-        hideEvent(event);
+        if (event.getChannel().equals(groupChat)) {
+            hideEvent(event);
+        }
     }
 
     private void hideEvent(final DisplayableEvent event) {

--- a/parserdebug/src/com/dmdirc/addons/parserdebug/ParserDebugManager.java
+++ b/parserdebug/src/com/dmdirc/addons/parserdebug/ParserDebugManager.java
@@ -134,10 +134,10 @@ public class ParserDebugManager {
 
     @Handler
     public void handleServerDisconnected(final ServerDisconnectedEvent event) {
-            final Parser parser = event.getConnection().getParser().get();
-            if (registeredParsers.containsKey(parser)) {
-                removeParser(parser, false);
-            }
+        final Parser parser = event.getConnection().getParser().get();
+        if (registeredParsers.containsKey(parser)) {
+            removeParser(parser, false);
+        }
     }
 
     @Handler

--- a/ui_swing/src/com/dmdirc/addons/ui_swing/components/NickList.java
+++ b/ui_swing/src/com/dmdirc/addons/ui_swing/components/NickList.java
@@ -224,23 +224,31 @@ public class NickList extends JScrollPane implements MouseListener {
 
     @Handler(invocation = EdtHandlerInvocation.class)
     public void handleClientsChanged(final NickListClientsChangedEvent event) {
-        nicklistModel.replace(event.getUsers());
+        if (event.getChannel().getWindowModel().equals(frame.getContainer())) {
+            nicklistModel.replace(event.getUsers());
+        }
     }
 
     @Handler(invocation = EdtHandlerInvocation.class)
     public void handleNickListUpdated(final NickListUpdatedEvent event) {
-        nicklistModel.sort();
-        repaint();
+        if (event.getChannel().getWindowModel().equals(frame.getContainer())) {
+            nicklistModel.sort();
+            repaint();
+        }
     }
 
     @Handler(invocation = EdtHandlerInvocation.class)
     public void handleClientAdded(final NickListClientAddedEvent event) {
-        nicklistModel.add(event.getUser());
+        if (event.getChannel().getWindowModel().equals(frame.getContainer())) {
+            nicklistModel.add(event.getUser());
+        }
     }
 
     @Handler(invocation = EdtHandlerInvocation.class)
     public void handleClientRemoved(final NickListClientRemovedEvent event) {
-        nicklistModel.remove(event.getUser());
+        if (event.getChannel().getWindowModel().equals(frame.getContainer())) {
+            nicklistModel.remove(event.getUser());
+        }
     }
 
 }

--- a/ui_swing/src/com/dmdirc/addons/ui_swing/components/TopicBar.java
+++ b/ui_swing/src/com/dmdirc/addons/ui_swing/components/TopicBar.java
@@ -228,12 +228,16 @@ public class TopicBar extends JComponent implements ActionListener, ConfigChange
 
     @Handler(invocation = EdtHandlerInvocation.class)
     public void handleTopicChanged(final ChannelTopicChangeEvent event) {
-        topicChanged(event.getChannel(), event.getTopic());
+        if (event.getChannel().equals(channel)) {
+            topicChanged(event.getChannel(), event.getTopic());
+        }
     }
 
     @Handler(invocation = EdtHandlerInvocation.class)
     public void handleTopicUnset(final ChannelTopicUnsetEvent event) {
-        topicChanged(event.getChannel(), null);
+        if (event.getChannel().equals(channel)) {
+            topicChanged(event.getChannel(), null);
+        }
     }
 
     private void topicChanged(final GroupChat channel, final Topic topic) {

--- a/ui_swing/src/com/dmdirc/addons/ui_swing/components/frames/ChannelFrame.java
+++ b/ui_swing/src/com/dmdirc/addons/ui_swing/components/frames/ChannelFrame.java
@@ -224,10 +224,12 @@ public final class ChannelFrame extends InputTextFrame {
     @Override
     @Handler(invocation = EdtHandlerInvocation.class)
     public void windowClosing(final FrameClosingEvent event) {
-        saveSplitPanePosition();
-        topicBar.close();
-        dialogProvider.dispose(groupChat);
-        super.windowClosing(event);
+        if (event.getSource().equals(getContainer())) {
+            saveSplitPanePosition();
+            topicBar.close();
+            dialogProvider.dispose(groupChat);
+            super.windowClosing(event);
+        }
     }
 
     @Override

--- a/ui_swing/src/com/dmdirc/addons/ui_swing/components/frames/ServerFrame.java
+++ b/ui_swing/src/com/dmdirc/addons/ui_swing/components/frames/ServerFrame.java
@@ -142,27 +142,33 @@ public final class ServerFrame extends InputTextFrame {
 
     @Handler(invocation = EdtHandlerInvocation.class)
     public void handleCertProblem(final ServerCertificateProblemEncounteredEvent event) {
-        if (sslDialog != null) {
-            sslDialog.dispose();
-        }
+        if (event.getConnection().equals(connection)) {
+            if (sslDialog != null) {
+                sslDialog.dispose();
+            }
 
-        sslDialog = sslDialogFactory.create(event);
-        sslDialog.display();
+            sslDialog = sslDialogFactory.create(event);
+            sslDialog.display();
+        }
     }
 
     @Handler(invocation = EdtHandlerInvocation.class)
     public void handleCertProblemResolved(final ServerCertificateProblemResolvedEvent event) {
-        if (sslDialog != null) {
-            sslDialog.dispose();
+        if (event.getConnection().equals(connection)) {
+            if (sslDialog != null) {
+                sslDialog.dispose();
+            }
         }
     }
 
     @Override
     @Handler(invocation = EdtHandlerInvocation.class)
     public void windowClosing(final FrameClosingEvent event) {
-        connection.getWindowModel().getEventBus().unsubscribe(this);
-        dialogProvider.dispose(connection);
-        super.windowClosing(event);
+        if (event.getSource().equals(frameParent)) {
+            connection.getWindowModel().getEventBus().unsubscribe(this);
+            dialogProvider.dispose(connection);
+            super.windowClosing(event);
+        }
     }
 
     @Override

--- a/windowflashing/src/com/dmdirc/addons/windowflashing/WindowFlashingManager.java
+++ b/windowflashing/src/com/dmdirc/addons/windowflashing/WindowFlashingManager.java
@@ -176,8 +176,6 @@ public class WindowFlashingManager {
         }
     }
 
-
-
     @Handler
     public void showConfig(final ClientPrefsOpenedEvent event) {
         final PreferencesDialogModel manager = event.getModel();


### PR DESCRIPTION
In preparation for child eventbusses being removed, anything
trying to subscribe to specific windows now needs an explicit
check.

In the process, fixed two issues:

- channel who plugin was sending way too many requests - each
  connection was querying every channel in the client. i.e.,
  with 5 servers open there'd be 5 WHOs per channel...

- ServerFrame stops itself listening when *any* frame is closed.
  So closing a channel window then reconnecting wouldn't offer
  an SSL dialog, because it's already unbound the listener.

Issue #662