### PR TITLE
Add a 'provided' scope.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+DMDirc plugins
+================================================================================
+
+This repository contains plugins for [DMDirc](https://www.dmdirc.com/), a Java
+IRC client.
+
+Development information
+--------------------------------------------------------------------------------
+
+### Gradle configurations
+
+We have two custom configurations for use when defining plugin dependencies:
+
+The **bundle** configuration allows dependencies to be bundled together into
+the plugin's jar file. This should be used for dependencies required at runtime
+that are not included in the main DMDirc client, or accessed via other plugins.
+Most of a plugin's dependencies should end up in the bundle configuration.
+
+The **provided** configuration works like the Maven 'provided' scope. It
+defines dependencies required to compile and run the plugin that will be
+provided to it somehow externally. Anything in the provided configuration
+(including transitive dependencies) will *not* be bundled into the plugin jar.
+The provided configuration is used for the main DMDirc client, and should be
+used for any intra-plugin dependencies.

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,11 @@ subprojects {
     }
 
     configurations {
-        bundle
+        provided
+
+        bundle {
+            extendsFrom provided
+        }
 
         compile {
             extendsFrom bundle
@@ -33,7 +37,7 @@ subprojects {
     }
 
     dependencies {
-        compile group: 'com.dmdirc', name: 'client', version: '+', changing: true
+        provided group: 'com.dmdirc', name: 'client', version: '+', changing: true
 
         compile group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.1'
         compile group: 'com.squareup.dagger', name: 'dagger-compiler', version: '1.2.4'
@@ -98,7 +102,7 @@ subprojects {
             into 'META-INF'
         }
 
-        from { configurations.bundle.collect { it.isDirectory() ? it : zipTree(it) } } {
+        from { configurations.bundle.minus(configurations.provided).collect { it.isDirectory() ? it : zipTree(it) } } {
             exclude 'META-INF/**'
         }
     }


### PR DESCRIPTION
This prevents DMDirc's transitive dependencies from being bundled
in plugins. e.g. DMDirc includes SLF4J, so any plugin that depends
on it (or depends on another project that depends on SLF4J) should
not include it in the plugin jar to avoid having duplicate classes
from different class loaders.