### PR TITLE
Remove some uses of Window.

### DIFF
--- a/ui_swing/src/main/java/com/dmdirc/addons/ui_swing/actions/CloseWindowAction.java
+++ b/ui_swing/src/main/java/com/dmdirc/addons/ui_swing/actions/CloseWindowAction.java
@@ -22,7 +22,7 @@
 
 package com.dmdirc.addons.ui_swing.actions;
 
-import com.dmdirc.interfaces.ui.Window;
+import com.dmdirc.interfaces.WindowModel;
 
 import java.awt.event.ActionEvent;
 
@@ -36,23 +36,22 @@ public final class CloseWindowAction extends AbstractAction {
     /** A version number for this class. */
     private static final long serialVersionUID = 1;
     /** Window to be closed. */
-    private final Window frame;
+    private final WindowModel window;
 
     /**
      * Instantiates a new close a window action.
      *
-     * @param frame window to be closed
+     * @param window window to be closed
      */
-    public CloseWindowAction(final Window frame) {
+    public CloseWindowAction(final WindowModel window) {
         super("Close");
-
-        this.frame = frame;
+        this.window = window;
     }
 
     @Override
     public void actionPerformed(final ActionEvent e) {
-        if (frame != null) {
-            frame.getContainer().close();
+        if (window != null) {
+            window.close();
         }
     }
 

--- a/ui_swing/src/main/java/com/dmdirc/addons/ui_swing/components/frames/CommandAction.java
+++ b/ui_swing/src/main/java/com/dmdirc/addons/ui_swing/components/frames/CommandAction.java
@@ -23,7 +23,7 @@
 package com.dmdirc.addons.ui_swing.components.frames;
 
 import com.dmdirc.commandparser.parsers.CommandParser;
-import com.dmdirc.interfaces.ui.Window;
+import com.dmdirc.interfaces.WindowModel;
 
 import java.awt.event.ActionEvent;
 
@@ -39,7 +39,7 @@ public class CommandAction extends AbstractAction {
     /** Command parser. */
     private final CommandParser parser;
     /** Window. */
-    private final transient Window window;
+    private final transient WindowModel window;
     /** Command. */
     private final String command;
 
@@ -51,7 +51,7 @@ public class CommandAction extends AbstractAction {
      * @param name    Command name
      * @param command Command to execute
      */
-    public CommandAction(final CommandParser parser, final Window window,
+    public CommandAction(final CommandParser parser, final WindowModel window,
             final String name, final String command) {
         super(name);
 
@@ -63,7 +63,7 @@ public class CommandAction extends AbstractAction {
     @Override
     public void actionPerformed(final ActionEvent e) {
         for (String line : command.split("\n")) {
-            parser.parseCommand(window.getContainer(), line);
+            parser.parseCommand(window, line);
         }
     }
 

--- a/ui_swing/src/main/java/com/dmdirc/addons/ui_swing/components/frames/TextFrame.java
+++ b/ui_swing/src/main/java/com/dmdirc/addons/ui_swing/components/frames/TextFrame.java
@@ -455,7 +455,7 @@ public abstract class TextFrame extends JPanel implements Window, TextPaneListen
                 menu.add(populatePopupMenu(new JMenu(menuItem.getName()),
                         menuItem.getSubMenu(), arguments));
             } else {
-                menu.add(new JMenuItem(new CommandAction(commandParser, this,
+                menu.add(new JMenuItem(new CommandAction(commandParser, getContainer(),
                         menuItem.getName(), menuItem.getCommand(arguments))));
             }
 

--- a/ui_swing/src/main/java/com/dmdirc/addons/ui_swing/framemanager/tree/Tree.java
+++ b/ui_swing/src/main/java/com/dmdirc/addons/ui_swing/framemanager/tree/Tree.java
@@ -259,7 +259,7 @@ public class Tree extends JTree implements MouseMotionListener, MouseListener, A
 
             popupMenu.add(moveUp);
             popupMenu.add(moveDown);
-            popupMenu.add(new JMenuItem(new CloseWindowAction(frame)));
+            popupMenu.add(new JMenuItem(new CloseWindowAction(frame.getContainer())));
             popupMenu.show(this, e.getX(), e.getY());
         }
     }

--- a/ui_swing/src/main/java/com/dmdirc/addons/ui_swing/textpane/TextPane.java
+++ b/ui_swing/src/main/java/com/dmdirc/addons/ui_swing/textpane/TextPane.java
@@ -23,8 +23,8 @@
 package com.dmdirc.addons.ui_swing.textpane;
 
 import com.dmdirc.addons.ui_swing.UIUtilities;
+import com.dmdirc.interfaces.WindowModel;
 import com.dmdirc.interfaces.config.ConfigChangeListener;
-import com.dmdirc.interfaces.ui.Window;
 import com.dmdirc.ui.messages.CachingDocument;
 import com.dmdirc.ui.messages.IRCDocument;
 import com.dmdirc.ui.messages.IRCDocumentListener;
@@ -73,8 +73,8 @@ public final class TextPane extends JComponent implements MouseWheelListener,
     private final TextPaneCanvas canvas;
     /** IRCDocument. */
     private final IRCDocument document;
-    /** Parent Frame. */
-    private final Window frame;
+    /** Parent window. */
+    private final WindowModel window;
     /** Indicator to show whether new lines have been added. */
     private final JLabel newLineIndicator;
     /** Background painter. */
@@ -94,18 +94,18 @@ public final class TextPane extends JComponent implements MouseWheelListener,
      * @param configDomain The domain to read configuration from.
      * @param urlBuilder   The builder to use to construct URLs for resources.
      * @param clipboard    The clipboard to handle copy and paste actions
-     * @param frame        Parent Frame
+     * @param window       Parent window
      */
     public TextPane(
             final String configDomain,
             final URLBuilder urlBuilder, final Clipboard clipboard,
-            final Window frame) {
-        this.frame = frame;
+            final WindowModel window) {
+        this.window = window;
         this.configDomain = configDomain;
         this.clipboard = clipboard;
 
         setUI(new TextPaneUI());
-        document = frame.getContainer().getBackBuffer().getDocument();
+        document = window.getBackBuffer().getDocument();
         newLineIndicator = new JLabel("", SwingConstants.CENTER);
         newLineIndicator.setBackground(Color.RED);
         newLineIndicator.setForeground(Color.WHITE);
@@ -113,7 +113,7 @@ public final class TextPane extends JComponent implements MouseWheelListener,
         newLineIndicator.setVisible(false);
 
         setLayout(new MigLayout("fill, hidemode 3"));
-        backgroundPainter = new BackgroundPainter(frame.getContainer().getConfigManager(),
+        backgroundPainter = new BackgroundPainter(window.getConfigManager(),
                 urlBuilder, configDomain, "textpanebackground",
                 "textpanebackgroundoption", "textpanebackgroundopacity");
         canvas = new TextPaneCanvas(this,
@@ -130,8 +130,7 @@ public final class TextPane extends JComponent implements MouseWheelListener,
         add(scrollBar, "dock east");
         scrollBar.addAdjustmentListener(this);
         scrollBar.addAdjustmentListener(canvas);
-        frame.getContainer().getConfigManager().addChangeListener(configDomain,
-                "textpanelinenotification", this);
+        window.getConfigManager().addChangeListener(configDomain, "textpanelinenotification", this);
         configChanged("", "textpanelinenotification");
 
         addMouseWheelListener(this);
@@ -497,8 +496,8 @@ public final class TextPane extends JComponent implements MouseWheelListener,
      *
      * @return Parent window
      */
-    public Window getWindow() {
-        return frame;
+    public WindowModel getWindow() {
+        return window;
     }
 
     /**
@@ -521,8 +520,7 @@ public final class TextPane extends JComponent implements MouseWheelListener,
 
     @Override
     public void configChanged(final String domain, final String key) {
-        showNotification = frame.getContainer().getConfigManager()
-                .getOptionBool(configDomain, "textpanelinenotification");
+        showNotification = window.getConfigManager().getOptionBool(configDomain, "textpanelinenotification");
         if (!showNotification) {
             UIUtilities.invokeLater(() -> newLineIndicator.setVisible(false));
         }

--- a/ui_swing/src/main/java/com/dmdirc/addons/ui_swing/textpane/TextPaneCanvas.java
+++ b/ui_swing/src/main/java/com/dmdirc/addons/ui_swing/textpane/TextPaneCanvas.java
@@ -103,7 +103,7 @@ class TextPaneCanvas extends JPanel implements MouseInputListener,
     public TextPaneCanvas(final TextPane parent, final CachingDocument<AttributedString> document) {
         this.document = document;
         textPane = parent;
-        this.manager = parent.getWindow().getContainer().getConfigManager();
+        this.manager = parent.getWindow().getConfigManager();
         this.lineRenderer = new BasicTextLineRenderer(textPane, this, document);
         startLine = 0;
         setDoubleBuffered(true);

--- a/ui_swing/src/main/java/com/dmdirc/addons/ui_swing/textpane/TextPaneFactory.java
+++ b/ui_swing/src/main/java/com/dmdirc/addons/ui_swing/textpane/TextPaneFactory.java
@@ -51,7 +51,7 @@ public class TextPaneFactory {
     }
 
     public TextPane getTextPane(final TextFrame frame) {
-        return new TextPane(configDomain, urlBuilder, clipboard, frame);
+        return new TextPane(configDomain, urlBuilder, clipboard, frame.getContainer());
     }
 
 }


### PR DESCRIPTION
Window only has a getContainer() method, so we may as well just
pass a WindowModel around instead.