### PR TITLE
Remove external usagees of ConfigSource.

### DIFF
--- a/debug/src/main/java/com/dmdirc/addons/debug/commands/ConfigInfo.java
+++ b/debug/src/main/java/com/dmdirc/addons/debug/commands/ConfigInfo.java
@@ -62,9 +62,7 @@ public class ConfigInfo extends DebugCommand {
     public void execute(@Nonnull final WindowModel origin,
             final CommandArguments args, final CommandContext context) {
         for (ConfigProvider source : origin.getConfigManager().getSources()) {
-            showOutput(origin, args.isSilent(), source.getTarget()
-                    + " - " + source + "(" + source.getTarget().getOrder()
-                    + ")");
+            showOutput(origin, args.isSilent(), String.valueOf(source));
         }
     }
 

--- a/debug/src/main/java/com/dmdirc/addons/debug/commands/GlobalConfigInfo.java
+++ b/debug/src/main/java/com/dmdirc/addons/debug/commands/GlobalConfigInfo.java
@@ -72,9 +72,7 @@ public class GlobalConfigInfo extends DebugCommand {
     public void execute(@Nonnull final WindowModel origin,
             final CommandArguments args, final CommandContext context) {
         for (ConfigProvider source : globalConfig.getSources()) {
-            showOutput(origin, args.isSilent(), source.getTarget()
-                    + " - " + source + "(" + source.getTarget().getOrder()
-                    + ")");
+            showOutput(origin, args.isSilent(), String.valueOf(source));
         }
     }
 

--- a/debug/src/main/java/com/dmdirc/addons/debug/commands/Identities.java
+++ b/debug/src/main/java/com/dmdirc/addons/debug/commands/Identities.java
@@ -83,13 +83,10 @@ public class Identities extends DebugCommand {
 
         int i = 0;
         for (ConfigProvider source : identities) {
-            data[i++] = new String[]{source.getName(),
-                source.getTarget().getTypeName(), source.getTarget().getData(),
-                String.valueOf(source.getTarget().getOrder())};
+            data[i++] = new String[]{source.getName()};
         }
 
-        showOutput(origin, args.isSilent(),
-                doTable(new String[]{"Name", "Target", "Data", "Priority"}, data));
+        showOutput(origin, args.isSilent(), doTable(new String[]{"Name"}, data));
     }
 
 }


### PR DESCRIPTION
This is an implementation detail, and it doesn't make sense to
expose it in an interface for everyone to access. The only use
of it outside of the config system is in debug displays.