### PR TITLE
Fix maven URL and dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ subprojects {
 
     repositories {
         mavenCentral()
-        maven { url 'https://artifactory.dmdirc.com/artifactory/repo' }
+        maven { url 'https://artifactory.dmdirc.com/artifactory/releases' }
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     }
 

--- a/identd/build.gradle
+++ b/identd/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    compile group: 'com.dmdirc.parser', name: 'irc', version: '+', changing: true
+    compile group: 'com.dmdirc', name: 'parser-irc', version: '+', changing: true
 }


### PR DESCRIPTION
Accessing 'repo' is bad practice and disabled in newer artifactory
versions (like the one we just deployed). Rely on releases instead.

Also, the identd plugin was depending on the wrong parser, and
was presumably pulling in criminally old versions from artifactory.