### PR TITLE
Rename custom jar and test tasks in plugins.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,8 +152,8 @@ task wrapper(type: Wrapper) {
 }
 
 subprojects.each { evaluationDependsOn it.path }
-task jar(dependsOn: subprojects*.jar)
-task test(dependsOn: subprojects*.test)
+task jars(dependsOn: subprojects*.jar)
+task tests(dependsOn: subprojects*.test)
 tasks.dependencies.dependsOn subprojects*.tasks.dependencies
 
 def plugin(name) {

--- a/circle.yml
+++ b/circle.yml
@@ -37,7 +37,7 @@ dependencies:
 
 test:
   override:
-    - ./gradlew --stacktrace plugins:jar plugins:test plugins:coveralls:
+    - ./gradlew --stacktrace plugins:jars plugins:tests plugins:coveralls:
         pwd:
           ../meta
 


### PR DESCRIPTION
IDEA gets super confused when you take a jar task and make it not a jar task.
These are only really used when running from CI (running `./gradlew jar` in
meta will still trigger all of the `:plugin:XXX:jar` tasks), so the names don't
matter.