### PR TITLE
Fix LoggingPlugin backbuffer not working, and open/close events going to the wrong file.

### DIFF
--- a/logging/src/main/java/com/dmdirc/addons/logging/LogFileLocator.java
+++ b/logging/src/main/java/com/dmdirc/addons/logging/LogFileLocator.java
@@ -122,27 +122,6 @@ public class LogFileLocator {
     }
 
     /**
-     * Get the name of the log file for a specific object.
-     *
-     * @param descriptor Description of the object to get a log file for.
-     *
-     * @return the name of the log file to use for this object.
-     */
-    public String getLogFile(@Nullable final String descriptor) {
-        final StringBuffer directory = getLogDirectory();
-        final StringBuffer file = new StringBuffer();
-        final String md5String;
-        if (descriptor == null) {
-            file.append("null.log");
-            md5String = "";
-        } else {
-            file.append(sanitise(descriptor.toLowerCase()));
-            md5String = descriptor;
-        }
-        return getPath(directory, file, md5String);
-    }
-
-    /**
      * Gets the path for the given file and directory. Only intended to be used from getLogFile
      * methods.
      *

--- a/logging/src/main/java/com/dmdirc/addons/logging/LoggingManager.java
+++ b/logging/src/main/java/com/dmdirc/addons/logging/LoggingManager.java
@@ -363,7 +363,8 @@ public class LoggingManager implements ConfigChangeListener {
 
     @Handler
     public void handleChannelOpened(final ChannelOpenedEvent event) {
-        final String filename = locator.getLogFile(event.getChannel().getName());
+        final String filename = locator.getLogFile(event.getChannel());
+        System.out.println("\tChannel opened filename: " + filename);
 
         if (autobackbuffer) {
             showBackBuffer(event.getChannel().getWindowModel(), filename);
@@ -377,7 +378,7 @@ public class LoggingManager implements ConfigChangeListener {
 
     @Handler
     public void handleChannelClosed(final ChannelClosedEvent event) {
-        final String filename = locator.getLogFile(event.getChannel().getName());
+        final String filename = locator.getLogFile(event.getChannel());
 
         synchronized (FORMAT_LOCK) {
             appendLine(filename, "*** Channel closed at: %s", OPENED_AT_FORMAT.format(new Date()));
@@ -558,18 +559,18 @@ public class LoggingManager implements ConfigChangeListener {
      * @return True if the history is available, false otherwise
      */
     protected boolean showHistory(final WindowModel target) {
-        final String descriptor;
+        final Path log;
 
         if (target instanceof GroupChat) {
-            descriptor = target.getName();
+            log = Paths.get(locator.getLogFile((GroupChat)target));
         } else if (target instanceof Query) {
-            descriptor = ((PrivateChat) target).getNickname();
+            log = Paths.get(locator.getLogFile(((PrivateChat) target).getUser()));
         } else {
             // Unknown component
             return false;
         }
 
-        final Path log = Paths.get(locator.getLogFile(descriptor));
+
 
         if (!Files.exists(log)) {
             // File doesn't exist


### PR DESCRIPTION
ChannelOpened/ChannelClosed events were passing a string rather than the channel object which meant that the network name was never being added properly to the channel. By passing in the GroupChat object we use the correct version of getLogFile.

Removing getLogFile(String) as it isn't really needed and just causes bugs like this.