### PR TITLE
Don't block for the EDT when an error is raised.

### DIFF
--- a/ui_swing/src/main/java/com/dmdirc/addons/ui_swing/components/statusbar/ErrorPanel.java
+++ b/ui_swing/src/main/java/com/dmdirc/addons/ui_swing/components/statusbar/ErrorPanel.java
@@ -147,12 +147,12 @@ public class ErrorPanel extends StatusbarPopupPanel<JLabel> implements ErrorsDia
 
     @Override
     public void errorDeleted(final DisplayableError error) {
-        UIUtilities.invokeAndWait(this::checkErrors);
+        UIUtilities.invokeLater(this::checkErrors);
     }
 
     @Override
     public void errorAdded(final DisplayableError error) {
-        UIUtilities.invokeAndWait(this::checkErrors);
+        UIUtilities.invokeLater(this::checkErrors);
     }
 
     @Override


### PR DESCRIPTION
This is prone to race conditions if an error occurs when
the EDT is waiting on a lock owned by the erroring thread.

Fixes DMDirc/DMDirc#805